### PR TITLE
Fix retinaface imports

### DIFF
--- a/crawler/requirements.txt
+++ b/crawler/requirements.txt
@@ -9,4 +9,5 @@ lxml>=5.3.0
 retina-face==0.0.17
 opencv-python-headless==4.9.0.80
 tensorflow==2.15.0
+tf-keras==2.15.0
 torch==2.2.1

--- a/embedder/requirements.txt
+++ b/embedder/requirements.txt
@@ -9,6 +9,7 @@ retina-face==0.0.17
 opencv-python-headless==4.9.0.80
 deepface==0.0.79
 tensorflow==2.15.0
+tf-keras==2.15.0
 mtcnn==0.1.1
 scikit-image==0.22.0
 torch==2.2.1

--- a/lookup/requirements.txt
+++ b/lookup/requirements.txt
@@ -6,6 +6,7 @@ flask==3.0.2
 retina-face==0.0.17
 opencv-python-headless==4.9.0.80
 tensorflow==2.15.0
+tf-keras==2.15.0
 torch==2.2.1
 selenium==4.18.1
 requests==2.31.0

--- a/video/requirements.txt
+++ b/video/requirements.txt
@@ -3,3 +3,5 @@ opencv-python-headless==4.9.0.80
 moviepy==1.0.3
 speechbrain==0.5.15
 minio==7.1.15
+tensorflow==2.15.0
+tf-keras==2.15.0


### PR DESCRIPTION
## Summary
- add missing tf-keras package
- install tensorflow for video service

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency lists to include tf-keras version 2.15.0 across multiple modules.
	- Added tensorflow version 2.15.0 to the video module’s dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->